### PR TITLE
Button that redirects from internships list to internship page

### DIFF
--- a/app/components/pages/Internships.js
+++ b/app/components/pages/Internships.js
@@ -4,6 +4,7 @@ import Collapsible from 'react-collapsible';
 import Title from 'components/elements/Title';
 import CollapsibleTrigger from 'components/elements/CollapsibleTrigger';
 import styled from 'styled-components';
+import Button from 'components/elements/Button';
 
 import { QUEEN_BLUE, AERO_BLUE, JAPANESE_INDIGO } from 'constants/colors';
 import InternshipForm from 'containers/elements/InternshipForm';
@@ -25,13 +26,22 @@ const InternshipsComponent = props => {
 
 
   const renderInternships = () => {
-    const { internships } = props;
+    const { internships, changeRoute } = props;
+    console.log('cr', changeRoute);
     return internships.map(internship => (
       <Collapsible key={internship.id} trigger={CollapsibleTrigger(internship)} triggerStyle={Trigger} >
         <InternshipContent key={internship.id}>
           <p><strong>Topic-uri: </strong>{internship.topics}</p>
           <p><strong>Locuri disponibile: </strong>{internship.places}</p>
           <p><strong>Durata: </strong>{internship.weeks} saptamani</p>
+          <ButtonWrapper>
+            <Button
+              text={`Vezi pagina ${internship.name}`}
+              onClick={
+                () => props.changeRoute(`/internship/${internship.id}/details`)
+              }>
+            </Button>
+          </ButtonWrapper>
         </InternshipContent>
       </Collapsible>
     ));
@@ -51,12 +61,17 @@ const InternshipsComponent = props => {
 const InternshipsContainer = styled.div`
   padding-left: 5%;
   padding-right: 5%;
+  background: ${AERO_BLUE};
 `;
 
 const InternshipContent = styled.div`
   font-size: 20;
   color: ${JAPANESE_INDIGO};
 `;
-
+const ButtonWrapper = styled.div`
+  width: 115px;
+  float: right;
+  margin-bottom: 5px;
+`;
 
 export default InternshipsComponent;

--- a/app/components/pages/Internships.js
+++ b/app/components/pages/Internships.js
@@ -27,7 +27,6 @@ const InternshipsComponent = props => {
 
   const renderInternships = () => {
     const { internships, changeRoute } = props;
-    console.log('cr', changeRoute);
     return internships.map(internship => (
       <Collapsible key={internship.id} trigger={CollapsibleTrigger(internship)} triggerStyle={Trigger} >
         <InternshipContent key={internship.id}>

--- a/app/containers/elements/InternshipForm/styles.js
+++ b/app/containers/elements/InternshipForm/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Collapse } from '@material-ui/core';
+import { AERO_BLUE } from 'constants/colors';
 
 export const FormWrapper = styled.div`
   margin:0 auto;
@@ -7,6 +8,8 @@ export const FormWrapper = styled.div`
   height:auto;
   z-index: 0;
   text-align:center;
+  background: ${AERO_BLUE};
+  padding-top: 14px;
 `;
 
 export const CollapseWrapper = styled(Collapse)`

--- a/app/containers/pages/Internships.js
+++ b/app/containers/pages/Internships.js
@@ -11,6 +11,7 @@ import InternshipsComponent from 'components/pages/Internships';
 import Alert from 'react-s-alert';
 import 'react-s-alert/dist/s-alert-default.css';
 import 'react-s-alert/dist/s-alert-css-effects/jelly.css';
+import { push } from 'react-router-redux';
 
 export class Internships extends React.Component {
   constructor(props) {
@@ -50,7 +51,7 @@ export class Internships extends React.Component {
 
     return (
       <div>
-      <InternshipsComponent internships={this.props.internships} />
+      <InternshipsComponent internships={this.props.internships} changeRoute={this.props.changeRoute} />
       </div>
     );
   }
@@ -63,6 +64,7 @@ const mapStateToProps = state =>
 
 const mapDispatchToProps = dispatch => ({
   getInternships: (redirectFunction) => dispatch(getInternships(redirectFunction)),
+  changeRoute: path => dispatch(push(path)),
 });
 
 const withConnect = connect(


### PR DESCRIPTION
Now every item of the list has this button when collapsed, which will redirect you to the internship's own page. The page of an internship is not yet available but it is in progress. (Internship page as seen by company).
Some minor styling was changed as well here.
@GhBogdan97 I have used the route that we agreed on WhatsApp `/internship/:id/details`. Make sure you use the same one, thank you :)